### PR TITLE
No need for verbose debug

### DIFF
--- a/src/commands/filter.yml
+++ b/src/commands/filter.yml
@@ -50,10 +50,6 @@ parameters:
     type: enum
     enum: [github, bitbucket]
     default: github
-  debug:
-    description: Print git diff-tree output, filtered or unfiltered, to stdout for debugging purposes.
-    type: boolean
-    default: false
   cache:
     description: Whether or not to cache (i.e. you're calling these commands in your own job, not 'continue').
     type: boolean
@@ -62,51 +58,6 @@ steps:
   - run:
       name: Generate changed modules
       command: |+
-        if << parameters.debug >>; then
-            pip install wildmatch==<< parameters.wildmatch-version >>
-
-            echo "<< parameters.modules >>" | awk NF | while read module; do
-                printf "Module: \"%s\"\\n" "$module"
-
-                module_dots="$(sed 's@\/@\.@g' \<<< "$module")"
-                if [ "${#module_dots}" -gt 1 ] && [ "${module_dots::1}" = "." ]; then
-                    module_dots="${module_dots:1}"
-                fi
-                if [ "${#module_dots}" -gt 1 ] && [ "${module_dots: -1}" = "." ]; then
-                    module_dots="${module_dots::-1}"
-                fi
-                echo "$module_dots"
-
-                module_slashes="$(sed 's@\.@\/@g' \<<< "$module")"
-                echo "$module_slashes"
-                if [ "${#module_slashes}" -gt 1 ] && [ "${module_slashes::1}" = "/" ]; then
-                    module_slashes="${module_slashes:1}"
-                fi
-                if [ "${#module_slashes}" -gt 1 ] && [ "${module_slashes: -1}" = "/" ]; then
-                    module_slashes="${module_slashes::-1}"
-                fi
-                echo "$module_slashes"
-
-                if [ "$module_dots" = "." ]; then
-                    if [ ! -f .circleci/"<< parameters.root-config >>.ignore" ]; then
-                        touch .circleci/"<< parameters.root-config >>.ignore"
-                    fi
-
-                    printf "%s\\n\\n" "<< parameters.root-config >>:"
-                    git diff-tree --no-commit-id --name-only -r HEAD << parameters.default-branch >> "$module_dots" | awk NF | wildmatch -c ".circleci/<< parameters.root-config >>.ignore"
-                    printf "\\n\\n"
-                else
-                    if [ ! -f .circleci/"${module_dots}.ignore" ]; then
-                        touch ".circleci/${module_dots}.ignore"
-                    fi
-
-                    printf "%s:\\n\\n" "$module_slashes"
-                    git diff-tree --no-commit-id --name-only -r HEAD << parameters.default-branch >> "$module_slashes" | awk NF | wildmatch -c ".circleci/${module_dots}.ignore"
-                    printf "\\n\\n"
-                fi
-            done
-        fi
-
         if [ ! "<< parameters.circle-token >>" ]; then
             printf "Must set CircleCI token for successful authentication.\\n" >&2
             exit 1
@@ -127,7 +78,7 @@ steps:
                 echo "$module_dots" >> << parameters.modules-filtered >>
             done
         else
-            if ! << parameters.debug >>; then pip install wildmatch==<< parameters.wildmatch-version >>; fi
+            pip install wildmatch==<< parameters.wildmatch-version >>
             echo "<< parameters.modules >>" | awk NF | while read module; do
                 module_dots="$(sed 's@\/@\.@g' \<<< "$module")"
                 if [ "${#module_dots}" -gt 1 ] && [ "${module_dots::1}" = "." ]; then

--- a/src/commands/reduce.yml
+++ b/src/commands/reduce.yml
@@ -27,10 +27,6 @@ parameters:
     description: Token to authenticate with CircleCI
     type: string
     default: $CIRCLE_TOKEN
-  debug:
-    description: Dump the generated config from reducing the set of modules across changes to stdout for debugging purposes.
-    type: boolean
-    default: false
   cache:
     description: Whether or not to cache (i.e. you're calling these commands in your own job, not 'extend').
     type: boolean
@@ -68,11 +64,3 @@ steps:
       name: CircleCI config validate reduced config
       command: |
         circleci config validate << parameters.continue-config >> --org-slug << parameters.project-type >>/<< parameters.circle-organization >> --token << parameters.circle-token >> --skip-update-check
-  - when:
-      condition: << parameters.debug >>
-      steps:
-        - run:
-            name: "Debug: dump generated config"
-            command: |
-              printf "Generated config:\\n\\n"
-              cat << parameters.continue-config >>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -61,10 +61,6 @@ parameters:
     type: enum
     enum: [github, bitbucket]
     default: github
-  debug:
-    description: Dump the reduced config to stdout for debugging purposes.
-    type: boolean
-    default: false
 
   # CircleCI continuation orb.
   parameters:
@@ -89,7 +85,6 @@ steps:
       default-branch: << parameters.default-branch >>
       root-config: << parameters.root-config >>
       reporting-window: << parameters.reporting-window >>
-      debug: << parameters.debug >>
       circle-organization: << parameters.circle-organization >>
       circle-token: << parameters.circle-token >>
       wildmatch-version: << parameters.wildmatch-version >>
@@ -104,7 +99,6 @@ steps:
       circle-organization: << parameters.circle-organization >>
       circle-token: << parameters.circle-token >>
       project-type: << parameters.project-type >>
-      debug: << parameters.debug >>
       cache: false
   - continuation/continue:
       configuration_path: << parameters.continue-config >>


### PR DESCRIPTION
## what

- Removes verbose debug

## why

Output is already produced for debugging purposes; this just dumps it twice and complicates the logic.

## references

