### PR TITLE
Fix the update check

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "install:pre-commit:mac": "brew install pre-commit",
     "install:pre-commit:pip": "pip install pre-commit",
     "install:pre-commit-hooks": "pre-commit install --install-hooks --allow-missing-config -t pre-commit -t prepare-commit-msg",
-    "orb:pack": "find src -maxdepth 1 -mindepth 1 -type d | xargs -I % basename % | xargs -I % ./scripts/pre-pack.sh src % && circleci orb pack src/ > orb.yml",
+    "orb:pack": "find src -maxdepth 1 -mindepth 1 -type d | xargs -I % basename % | xargs -I % ./scripts/pre-pack.sh src % && circleci orb pack --skip-update-check src/ > orb.yml",
     "orb:validate": "./scripts/validate.sh",
     "orb:cleanup": "find src -maxdepth 1 -mindepth 1 -type d | xargs -I % basename % | xargs -I % ./scripts/rev-pack.sh src %; yes | rm orb.yml",
     "orb:clean": "yarn orb:cleanup",


### PR DESCRIPTION
## what

- `yarn orb:validate` runs `circleci orb pack` without the skip update check flag.

## why

- This results in some nonsense in the packed orb.

## references

N/A