### PR TITLE
fix-auto-detection: root-config not adequately handled

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
-nodejs   18.9.0
-yarn     1.22.19
+nodejs      18.9.0
+yarn        1.22.19
+shellcheck  0.9.0

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
 
-asdf plugin add nodejs   https://github.com/asdf-vm/asdf-nodejs.git
-asdf plugin-add yarn     https://github.com/twuni/asdf-yarn.git
+asdf plugin add nodejs      https://github.com/asdf-vm/asdf-nodejs.git
+asdf plugin-add yarn        https://github.com/twuni/asdf-yarn.git
+asdf plugin add shellcheck  https://github.com/luizm/asdf-shellcheck.git

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,5 +10,4 @@ display:
 
 orbs:
   continuation: circleci/continuation@0.3.1
-  jq: circleci/jq@2.2.0
   circleci: circleci/circleci-cli@0.1.9

--- a/src/commands/filter.yml
+++ b/src/commands/filter.yml
@@ -82,6 +82,7 @@ steps:
         SH_SQUASH_MERGE_LOOKBEHIND: << parameters.squash-merge-lookbehind >>
         SH_INCLUDE_CONFIG_CHANGES: << parameters.include-config-changes >>
         SH_AUTO_DETECT: << parameters.auto-detect >>
+        SH_ROOT_MODULE: << parameters.root-config >>
       command: << include(scripts/filter.sh) >>
   - when:
       condition: << parameters.cache >>

--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -35,7 +35,7 @@ done
 # If auto-detecting is enabled (or modules aren't set), check for configs in .circleci/.
 if [ "$SH_AUTO_DETECT" -eq 1 ] || [ "$SH_MODULES" = "" ]; then
     # We need to determine what the modules are, ignoring SH_MODULES if it is set.
-    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -v config | sed "s@$SH_ROOT_MODULE@\.@")"
+    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -v config | sed "s@$SH_ROOT_MODULE@.@")"
     printf "Auto-detected the following modules:\\n\\n%s\\n\\n" "$SH_MODULES"
 fi
 

--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -35,7 +35,7 @@ done
 # If auto-detecting is enabled (or modules aren't set), check for configs in .circleci/.
 if [ "$SH_AUTO_DETECT" -eq 1 ] || [ "$SH_MODULES" = "" ]; then
     # We need to determine what the modules are, ignoring SH_MODULES if it is set.
-    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -v config)"
+    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -v config | sed "s@$SH_ROOT_MODULE@\.@")"
     printf "Auto-detected the following modules:\\n\\n%s\\n\\n" "$SH_MODULES"
 fi
 

--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -35,7 +35,7 @@ done
 # If auto-detecting is enabled (or modules aren't set), check for configs in .circleci/.
 if [ "$SH_AUTO_DETECT" -eq 1 ] || [ "$SH_MODULES" = "" ]; then
     # We need to determine what the modules are, ignoring SH_MODULES if it is set.
-    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -v config | sed "s@$SH_ROOT_MODULE@.@")"
+    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -v config | sed "s@${SH_ROOT_MODULE}@.@")"
     printf "Auto-detected the following modules:\\n\\n%s\\n\\n" "$SH_MODULES"
 fi
 


### PR DESCRIPTION
## what

- Solves #37 as root modules aren't adequately handled presently by auto-detection.

## why

- We need to perform the equivalent of a reverse lookup.

## references

#37 