### PR TITLE
pin-circleci-cli-version: CircleCI CLI has a bug

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -104,6 +104,11 @@ parameters:
     description: A script to run after checkout and before any continuation logic. Script should have a shebang and executable.
     type: string
     default: ''
+  # CircleCI CLI orb.
+  circleci-cli-version:
+    description: Version of the CircleCI CLI to install. (Cf. https://github.com/CircleCI-Public/circleci-cli/releases.)
+    type: string
+    default: v0.1.23845
 steps:
   - checkout
   - when:
@@ -121,7 +126,8 @@ steps:
       command: |+
         curl -sSL https://github.com/mikefarah/yq/releases/download/<< parameters.yq-version >>/yq_linux_amd64 -o yq
         sudo install yq /usr/local/bin/yq
-  - circleci/install
+  - circleci/install:
+      version: << parameters.circleci-cli-version >>
   - filter:
       modules: << parameters.modules >>
       modules-filtered: << parameters.modules-filtered >>

--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -16,6 +16,20 @@ else
     _CIRCLE_ORGANIZATION="$SH_CIRCLE_ORGANIZATION"
 fi
 
+
+##
+# Recursively eval-echo any environment variables that start with SH_*
+function sh_eval()
+{
+    if [ $# -ne 1 ]; then
+        printf "Function \"sh_eval\" expected at least 1 argument: environment variable name." >&2
+        exit 1
+    fi
+
+
+}
+
+
 # CircleCI API token should be set.
 if [ -z "$_CIRCLE_TOKEN" ]; then
     printf "Must set CircleCI token for successful authentication.\\n" >&2


### PR DESCRIPTION
## what

https://github.com/CircleCI-Public/circleci-cli/issues/895

## why

- CircleCI CLI version that's installed for validation isn't pinned as it should be.

## references

https://github.com/CircleCI-Public/circleci-cli/issues/895