### PR TITLE
feat: Support custom executor

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -1,8 +1,12 @@
 description: |
   Extend the default CircleCI config at .circleci/config.yml to include other 'modules', then submit it as a continuation.
-executor: python
+executor: << parameters.executor >>
 resource_class: << parameters.resource-class >>
 parameters:
+  executor:
+    description: The name of the custom executor to use.
+    type: executor
+    default: python
   resource-class:
     type: enum
     enum: [small, medium, large, xlarge, 2xlarge]


### PR DESCRIPTION
## what

- Support custom executor parameter

## why

- In a Python-based project, its common to have a .python-version specified. This currently results in an exception in the filter step with a mismatched python version from the default python executor.

## references

- See https://github.com/bjd2385/dynamic-continuation-orb/issues/54