### PR TITLE
debug-logging: add debug logging

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -128,7 +128,7 @@ steps:
   - run:
       name: 'Pre: Install jq'
       command: |+
-        if ! sudo apt show jq 2>/dev/null | grep "Version: << parameters.jq-version >>" >/dev/null; then
+        if ! sudo apt show jq 2>/dev/null | grep -q "Version: << parameters.jq-version >>"; then
             sudo apt update
             sudo apt install -y jq=<< parameters.jq-version >>
         fi

--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -49,7 +49,7 @@ info()
 debug()
 {
     if [ $# -ne 1 ]; then
-        printf "Function \"info\" expected at least 1 argument: info message.\\n" >&2
+        printf "Function \"debug\" expected at least 1 argument: debug message.\\n" >&2
         exit 1
     fi
 
@@ -183,6 +183,7 @@ IGNORE
             # Concatenate generated ignore with user-provided config.
             mv ".circleci/${module_dots}.ignore" ".circleci/${module_dots}.ignore.bak"
             cat ".circleci/${module_dots}.ignore.tmp" ".circleci/${module_dots}.ignore.bak" > ".circleci/${module_dots}.ignore"
+            rm ".circleci/${module_dots}.ignore.bak" ".circleci/${module_dots}.ignore.tmp"
         fi
 
         if [ "$CIRCLE_BRANCH" = "$SH_DEFAULT_BRANCH" ]; then


### PR DESCRIPTION
## what

- Implement #56 

## why

- Debug logging is always helpful for users to understand why their workflow is being ran.

## references

#56