### PR TITLE
feat: Check presence of jq before installing

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -128,7 +128,7 @@ steps:
   - run:
       name: 'Pre: Install jq'
       command: |+
-        sudo apt update && sudo apt install -y jq=<< parameters.jq-version >>
+        sudo apt show jq | grep "Version: << parameters.jq-version >>" || sudo apt update && sudo apt install -y jq=<< parameters.jq-version >>
   - run:
       name: 'Pre: Install yq'
       command: |+


### PR DESCRIPTION
## what

- Check presence of specified jq version before installing

## why

- The jq install step is observed to occasionally take up to 45s as it depends on `apt update`
- This temporarily resolves the issue by checking for the presence of the specified jq version before installing

## references

- See https://github.com/bjd2385/dynamic-continuation-orb/issues/61
