### PR TITLE
postpone-checkout: ensure artifacts don't interfere

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -118,12 +118,6 @@ parameters:
     type: string
     default: v0.1.23845
 steps:
-  - when:
-      condition: << parameters.pre-script >>
-      steps:
-        - run:
-            name: 'Pre: Run pre-script'
-            command: << parameters.pre-script >>
   - run:
       name: 'Pre: Install jq'
       command: |+
@@ -140,6 +134,12 @@ steps:
   - circleci/install:
       version: << parameters.circleci-cli-version >>
   - checkout
+  - when:
+      condition: << parameters.pre-script >>
+      steps:
+        - run:
+            name: 'Pre: Run pre-script'
+            command: << parameters.pre-script >>
   - filter:
       modules: << parameters.modules >>
       modules-filtered: << parameters.modules-filtered >>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -118,7 +118,6 @@ parameters:
     type: string
     default: v0.1.23845
 steps:
-  - checkout
   - when:
       condition: << parameters.pre-script >>
       steps:
@@ -140,6 +139,7 @@ steps:
         rm yq
   - circleci/install:
       version: << parameters.circleci-cli-version >>
+  - checkout
   - filter:
       modules: << parameters.modules >>
       modules-filtered: << parameters.modules-filtered >>


### PR DESCRIPTION
## what

- test postponing the checkout until after dependencies are installed to avoid triggering pipelines with potential artifacts.

## why

- Future-proofing

## references

N/A