### PR TITLE
validate-private-orbs: split cases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "packageRules": [
       {
         "matchDatasources": ["orb"],
-        "fileMatch": ["^.config/.*\\.yml$"]
+        "fileMatch": ["^.circleci/.*\\.yml$"]
       }
     ]
   }

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -82,13 +82,6 @@ parameters:
     type: enum
     enum: [github, gitlab, bitbucket]
     default: github
-  private-validation:
-    description: |+
-      Validating a private orb requires an org slug and token to be passed to 'circleci config validate'. See also the following issue to determine if this problem is relevant to you:
-
-      https://github.com/bjd2385/dynamic-continuation-orb/issues/81
-    type: boolean
-    default: false
   jq-version:
     description:
       Version of jq to install.
@@ -181,20 +174,10 @@ steps:
       project-type: << parameters.project-type >>
       cache: false
       debug: << parameters.debug >>
-  - unless:
-      condition: << parameters.private-validation >>
-      steps:
-        - run:
-            name: 'Validate: public'
-            command: |
-              circleci config validate << parameters.continue-config >>
-  - when:
-      condition: << parameters.private-validation >>
-      steps:
-        - run:
-            name: 'Validate: private'
-            command: |
-              circleci config validate << parameters.continue-config >> --org-slug << parameters.circle-organization >> --token << parameters.circle-token >>
+  - run:
+      name: Validate
+      command: |
+        circleci config validate << parameters.continue-config >> --org-slug << parameters.circle-organization >> --token << parameters.circle-token >>
   - continuation/continue:
       configuration_path: << parameters.continue-config >>
       parameters: << parameters.parameters >>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -177,7 +177,7 @@ steps:
   - run:
       name: Validate
       command: |
-        circleci config validate << parameters.continue-config >> --org-slug << parameters.circle-organization >> --token << parameters.circle-token >>
+        circleci config validate << parameters.continue-config >> --org-slug <<parameters.project-type >>/<< parameters.circle-organization >> --token << parameters.circle-token >>
   - continuation/continue:
       configuration_path: << parameters.continue-config >>
       parameters: << parameters.parameters >>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -182,14 +182,14 @@ steps:
       cache: false
       debug: << parameters.debug >>
   - unless:
-      condition: << parameters.private-orb-validation >>
+      condition: << parameters.private-validation >>
       steps:
         - run:
             name: 'Validate: public'
             command: |
               circleci config validate << parameters.continue-config >>
   - when:
-      condition: << parameters.private-orb-validation >>
+      condition: << parameters.private-validation >>
       steps:
         - run:
             name: 'Validate: private'

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -82,6 +82,13 @@ parameters:
     type: enum
     enum: [github, gitlab, bitbucket]
     default: github
+  private-validation:
+    description: |+
+      Validating a private orb requires an org slug and token to be passed to 'circleci config validate'. See also the following issue to determine if this problem is relevant to you:
+
+      https://github.com/bjd2385/dynamic-continuation-orb/issues/81
+    type: boolean
+    default: false
   jq-version:
     description:
       Version of jq to install.
@@ -112,6 +119,7 @@ parameters:
     description: A script to run after checkout and before any continuation logic. Script should have a shebang and executable.
     type: string
     default: ''
+
   # CircleCI CLI orb.
   circleci-cli-version:
     description: Version of the CircleCI CLI to install. (Cf. https://github.com/CircleCI-Public/circleci-cli/releases.)
@@ -173,10 +181,20 @@ steps:
       project-type: << parameters.project-type >>
       cache: false
       debug: << parameters.debug >>
-  - run:
-      name: Validate
-      command: |
-        circleci config validate << parameters.continue-config >>
+  - unless:
+      condition: << parameters.private-orb-validation >>
+      steps:
+        - run:
+            name: 'Validate: public'
+            command: |
+              circleci config validate << parameters.continue-config >>
+  - when:
+      condition: << parameters.private-orb-validation >>
+      steps:
+        - run:
+            name: 'Validate: private'
+            command: |
+              circleci config validate << parameters.continue-config >> --org-slug << parameters.circle-organization >> --token << parameters.circle-token >>
   - continuation/continue:
       configuration_path: << parameters.continue-config >>
       parameters: << parameters.parameters >>


### PR DESCRIPTION
## what

- Allows validation of private orbs.

## why

- Presently, only public orb validation is supported. We should support private cases, also.

## references

#81 