### PR TITLE
fix: change grep to filter out root circleci config only

### DIFF
--- a/src/scripts/filter.sh
+++ b/src/scripts/filter.sh
@@ -96,7 +96,7 @@ done
 # If auto-detecting is enabled (or modules aren't set), check for configs in .circleci/.
 if [ "$SH_AUTO_DETECT" -eq 1 ] || [ "$SH_MODULES" = "" ]; then
     # We need to determine what the modules are, ignoring SH_MODULES if it is set.
-    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -v config | sed "s@${SH_ROOT_MODULE}@.@")"
+    SH_MODULES="$(find .circleci/ -type f -name "*.yml" | grep -oP "(?<=.circleci/).*(?=.yml)" | grep -v "^/config$" | sed "s@${SH_ROOT_MODULE}@.@")"
     info "auto-detected the following modules:
 
 $SH_MODULES


### PR DESCRIPTION
Me again 🫠

Proposed (small) change to allow directories that have `config` somewhere in their path.

Our use case is [great expectations](https://docs.greatexpectations.io/docs/).  This uses a directory `config` to store all the expectation suites/connection details etc. We build Docker images when files in this config directory are changed, but currently the orb excludes all directories that have `config` in the name when using auto-detection.

If I understand correctly the filter stage wants to get a list of all the modules in `.circleci`, but exclude the root `config.yml` that CircleCI uses.

Currently:
<img width="1161" alt="image" src="https://github.com/bjd2385/dynamic-continuation-orb/assets/53234158/5d19b5f8-19da-4d1e-99d0-bfa3dd2ee836">

With proposed change (containing `/airflow.custom_containers.great_expectations.config.docs`):
<img width="1176" alt="image" src="https://github.com/bjd2385/dynamic-continuation-orb/assets/53234158/50e0826d-2c0c-4965-8be1-377f83245ed1">


## what

- The filter step currently runs `grep -v config` to filter out the root circleci config.yml.
- This means any modules with `config` in their directory paths are excluded when auto-detect is `true`.

## why

- Changing the grep filter to `"^/config$"` will allow modules that have a directory containing `config` in their path while excluding the root circleci file.

## references

n/a